### PR TITLE
Fixed Windows scRGB screenshots + Game Brightness

### DIFF
--- a/common/src/main/java/xyz/rrtt217/HDRMod/core/PngjHDRScreenshot.java
+++ b/common/src/main/java/xyz/rrtt217/HDRMod/core/PngjHDRScreenshot.java
@@ -110,7 +110,7 @@ public class PngjHDRScreenshot {
                             for (int c = 0; c < 4; c++) {
                                 bits = mappedView.data().getShort(basePos + c * 2);
                                 datas[c] = Float.float16ToFloat(bits);
-                                if (System.getProperty("os.name").startsWith("Windows")) datas[c] *= 80.f / config.customGamePaperWhiteBrightness; //Fixes Game Brightness scaling for Windows.
+                                if (HDRMod.WindowTransferFunction == Enums.TransferFunction.EXT_LINEAR) datas[c] *= 80.f / config.customGamePaperWhiteBrightness; //Fixes Game Brightness scaling for Windows.
                             }
                             // Do transform.
                             if (doPrimariesTransform) {


### PR DESCRIPTION
On Windows, scRGB screenshots were incorrectly affected by Game Brightness when != 80.
(WearyOlly confirmed it's not on Linux.)
TODO: rgba16unorm

Fix:
```
// RGBA16F.
for (int c = 0; c < 4; c++) {
    bits = mappedView.data().getShort(basePos + c * 2);
    datas[c] = Float.float16ToFloat(bits);
    if (System.getProperty("os.name").startsWith("Windows")) datas[c] *= 80.f / config.customGamePaperWhiteBrightness; //Fixes Game Brightness scaling for Windows.
}
```